### PR TITLE
Support adding default tags as discrete values in LoggerConfiguration…

### DIFF
--- a/src/Serilog.Sinks.Exceptionless/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Exceptionless/LoggerSinkConfigurationExtensions.cs
@@ -32,13 +32,14 @@ namespace Serilog
             if (apiKey == null)
                 throw new ArgumentNullException(nameof(apiKey));
 
-            return loggerConfiguration.Sink(new ExceptionlessSink(apiKey, null, additionalOperation, includeProperties), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(new ExceptionlessSink(apiKey, null, null, additionalOperation, includeProperties), restrictedToMinimumLevel);
         }
-        
+
         /// <summary>Creates a new Exceptionless sink with the specified <paramref name="apiKey"/>.</summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="apiKey">The API key that will be used when sending events to the server.</param>
         /// <param name="serverUrl">Optional URL of the server events will be sent to.</param>
+        /// <param name="defaultTags">Default tags to be added to every log event.</param>
         /// <param name="additionalOperation">Any additional operation to run against the build exceptions</param>
         /// <param name="includeProperties">If false it suppressed sending the Serilog properties to Exceptionless</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
@@ -48,6 +49,7 @@ namespace Serilog
             this LoggerSinkConfiguration loggerConfiguration,
             string apiKey,
             string serverUrl = null,
+            string[] defaultTags = null,
             Func<EventBuilder, EventBuilder> additionalOperation = null,
             bool includeProperties = true,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum
@@ -58,7 +60,7 @@ namespace Serilog
             if (apiKey == null)
                 throw new ArgumentNullException(nameof(apiKey));
 
-            return loggerConfiguration.Sink(new ExceptionlessSink(apiKey, serverUrl, additionalOperation, includeProperties), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(new ExceptionlessSink(apiKey, serverUrl, defaultTags, additionalOperation, includeProperties), restrictedToMinimumLevel);
         }
 
         /// <summary>Creates a new Exceptionless sink.</summary>

--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Exceptionless;
 using Exceptionless.Dependency;
 using Exceptionless.Logging;
@@ -96,10 +95,8 @@ namespace Serilog.Sinks.Exceptionless {
 
             var builder = _client.CreateFromLogEvent(logEvent);
 
-            if (_defaultTags != null && _defaultTags.Any()) {
-                builder.AddTags(_defaultTags);
-            }
-            
+            builder.AddTags(_defaultTags);
+
             if (_includeProperties && logEvent.Properties != null) {
                 foreach (var prop in logEvent.Properties)
                 {


### PR DESCRIPTION
… extension

*Motivation*

When Exceptionles sink is used together with serilog-settings-configuration package then it can be configured in appsettings.json:
```
"Serilog": {
    "WriteTo": [
        {
            "Name": "Exceptionless",
            "Args": {
                "apiKey": "<my-api-key>"
            }
        }
    ]
}
```
with the configuration code:

`loggerConfiguration.ReadFrom.Configuration(cfg);`

In this case it is not possible to add default tags to the sink.

The PR adds the possibility to configure default tags in appsettings.json:
```
"Serilog": {
    "WriteTo": [
        {
            "Name": "Exceptionless",
            "Args": {
                "apiKey": "<my-api-key>",
                "defaultTags": ["tag1", "tag2"]
            }
        }
    ]
}
```