### PR TITLE
fix Serilog.MinimumLevel not working

### DIFF
--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
@@ -93,10 +93,6 @@ namespace Serilog.Sinks.Exceptionless {
             if (logEvent == null || !_client.Configuration.IsValid)
                 return;
 
-            var minLogLevel = _client.Configuration.Settings.GetMinLogLevel(logEvent.GetSource());
-            if (logEvent.GetLevel() < minLogLevel)
-                return;
-
             var builder = _client.CreateFromLogEvent(logEvent).AddTags(_defaultTags);
 
             if (_includeProperties && logEvent.Properties != null) {


### PR DESCRIPTION
The MinimumLevel has been configured in Serilog, so it should report to ExceptionLess according to the set MinimumLevel. Therefore, the default configuration in the ExceptionLess Client should be ignored.When initializing the Sink, the restrictedToMinimumLevel parameter is provided, which specifies the minimum log level that will be sent to the Sink.
fix #14 