### PR TITLE
fix Serilog.MinimumLevel not working and use restrictedToMinimumLevel

### DIFF
--- a/src/Serilog.Sinks.Exceptionless/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Exceptionless/LoggerSinkConfigurationExtensions.cs
@@ -32,7 +32,7 @@ namespace Serilog
             if (apiKey == null)
                 throw new ArgumentNullException(nameof(apiKey));
 
-            return loggerConfiguration.Sink(new ExceptionlessSink(apiKey, null, null, additionalOperation, includeProperties), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(new ExceptionlessSink(apiKey, null, null, additionalOperation, includeProperties, restrictedToMinimumLevel), restrictedToMinimumLevel);
         }
 
         /// <summary>Creates a new Exceptionless sink with the specified <paramref name="apiKey"/>.</summary>
@@ -60,7 +60,7 @@ namespace Serilog
             if (apiKey == null)
                 throw new ArgumentNullException(nameof(apiKey));
 
-            return loggerConfiguration.Sink(new ExceptionlessSink(apiKey, serverUrl, defaultTags, additionalOperation, includeProperties), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(new ExceptionlessSink(apiKey, serverUrl, defaultTags, additionalOperation, includeProperties, restrictedToMinimumLevel), restrictedToMinimumLevel);
         }
 
         /// <summary>Creates a new Exceptionless sink.</summary>

--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessClientExtensions.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessClientExtensions.cs
@@ -13,7 +13,7 @@ namespace Serilog.Sinks.Exceptionless
 
             var builder = log.Exception != null
                 ? client.CreateException(log.Exception)
-                : client.CreateLog(log.GetSource(), message, log.GetLevel());
+                : client.CreateLog(log.GetSource(), message, log.Level.GetLevel());
 
             builder.Target.Date = log.Timestamp;
             if (log.Level == LogEventLevel.Fatal)
@@ -34,25 +34,6 @@ namespace Serilog.Sinks.Exceptionless
                 return value.FlattenProperties()?.ToString();
 
             return null;
-        }
-
-        internal static LogLevel GetLevel(this LogEvent log) {
-            switch (log.Level) {
-                case LogEventLevel.Verbose:
-                    return LogLevel.Trace;
-                case LogEventLevel.Debug:
-                    return LogLevel.Debug;
-                case LogEventLevel.Information:
-                    return LogLevel.Info;
-                case LogEventLevel.Warning:
-                    return LogLevel.Warn;
-                case LogEventLevel.Error:
-                    return LogLevel.Error;
-                case LogEventLevel.Fatal:
-                    return LogLevel.Fatal;
-                default:
-                    return LogLevel.Other;
-            }
         }
 
         internal static LogLevel GetLevel(this LogEventLevel log)

--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessClientExtensions.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessClientExtensions.cs
@@ -55,6 +55,27 @@ namespace Serilog.Sinks.Exceptionless
             }
         }
 
+        internal static LogLevel GetLevel(this LogEventLevel log)
+        {
+            switch (log)
+            {
+                case LogEventLevel.Verbose:
+                    return LogLevel.Trace;
+                case LogEventLevel.Debug:
+                    return LogLevel.Debug;
+                case LogEventLevel.Information:
+                    return LogLevel.Info;
+                case LogEventLevel.Warning:
+                    return LogLevel.Warn;
+                case LogEventLevel.Error:
+                    return LogLevel.Error;
+                case LogEventLevel.Fatal:
+                    return LogLevel.Fatal;
+                default:
+                    return LogLevel.Other;
+            }
+        }
+
         /// <summary>
         /// Removes the structure of <see cref="LogEventPropertyValue"/> implementations introduced
         /// by Serilog and brings properties closer to the structure of the original object.

--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
@@ -37,12 +37,16 @@ namespace Serilog.Sinks.Exceptionless {
         /// <param name="includeProperties">
         /// If false then the Serilog properties will not be submitted to Exceptionless
         /// </param>
+        /// <param name="restrictedToMinimumLevel">
+        /// The minimum log event level required in order to write an event to the sink.
+        /// </param>
         public ExceptionlessSink(
             string apiKey,
             string serverUrl = null,
             string[] defaultTags = null,
             Func<EventBuilder, EventBuilder> additionalOperation = null,
-            bool includeProperties = true
+            bool includeProperties = true,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum
         ) {
             if (apiKey == null)
                 throw new ArgumentNullException(nameof(apiKey));
@@ -56,6 +60,7 @@ namespace Serilog.Sinks.Exceptionless {
 
                 config.UseInMemoryStorage();
                 config.UseLogger(new SelfLogLogger());
+                config.SetDefaultMinLogLevel(restrictedToMinimumLevel.GetLevel());
             });
 
             _defaultTags = defaultTags;
@@ -94,6 +99,10 @@ namespace Serilog.Sinks.Exceptionless {
                 return;
 
             var builder = _client.CreateFromLogEvent(logEvent).AddTags(_defaultTags);
+
+            var minLogLevel = _client.Configuration.Settings.GetMinLogLevel(logEvent.GetSource());
+            if (logEvent.GetLevel() < minLogLevel)
+                return;
 
             if (_includeProperties && logEvent.Properties != null) {
                 foreach (var prop in logEvent.Properties)

--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
@@ -98,11 +98,11 @@ namespace Serilog.Sinks.Exceptionless {
             if (logEvent == null || !_client.Configuration.IsValid)
                 return;
 
-            var builder = _client.CreateFromLogEvent(logEvent).AddTags(_defaultTags);
-
             var minLogLevel = _client.Configuration.Settings.GetMinLogLevel(logEvent.GetSource());
-            if (logEvent.GetLevel() < minLogLevel)
+            if (logEvent.Level.GetLevel() < minLogLevel)
                 return;
+
+            var builder = _client.CreateFromLogEvent(logEvent).AddTags(_defaultTags);
 
             if (_includeProperties && logEvent.Properties != null) {
                 foreach (var prop in logEvent.Properties)


### PR DESCRIPTION
.. to set default level.
fix #16  Ignoring the client default log level setting resulted in the potential inability to upload logs with a level below warn.

https://github.com/exceptionless/Exceptionless.Net/issues/260 This issue has also been fixed.It is now possible to configure the 
 minimum log level using Serilog.
like this.
```
"Serilog": {
    "Using": [ "Serilog.Sinks.ExceptionLess" ],
    "MinimumLevel": {
      //global minimumLevel
      "Default": "Debug",
      "Override": {
        "Microsoft": "Warning",
        "System": "Warning"
      }
    },
    "WriteTo": [
      {
        "Name": "Exceptionless",
        "Args": {
          "apiKey": "xxxxxxxx",
          "serverUrl": "http://xxxxxx/"
          //If you want to specify a specific level, will update client's minimum log level
          "restrictedToMinimumLevel": "Error"
        }
      }
    ]
  }
```
![image](https://user-images.githubusercontent.com/6287552/234889385-9e16b460-6063-4cfc-a1a0-715906c435d8.png)
