### PR TITLE
Added tag support for including tags in the exceptionless feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 ```
 
+To get tags to populate on the exceptionless UI, add a `Tags` string enumerable to any log.
+
+```Example with Serilog: 
+Serilog: Log.ForContext("Tags", new List() { "Tag1", "Tag2"}).Information("Seri info");
+```
+
+```Example with ILogger
+using (var scope = _logger.BeginScope(new Dictionary<string, object> { ["Tags"] = new string[] { "Tag1", "Tag2" }}))
+{
+_logger.Log(logLevel, eventId, state, exception, formatter);
+}
+```
+
 * [Documentation](https://github.com/serilog/serilog/wiki)
 
 Copyright &copy; 2023 Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html).

--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessClientExtensions.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessClientExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Exceptionless;
 using Exceptionless.Logging;
 using Serilog.Core;
@@ -34,6 +35,24 @@ namespace Serilog.Sinks.Exceptionless
                 return value.FlattenProperties()?.ToString();
 
             return null;
+        }
+
+        internal static string[] GetTags(this LogEvent log)
+        {
+            if (log.Properties.TryGetValue("Tags", out LogEventPropertyValue value))
+            {
+                var propertyCollection = value.FlattenProperties() as List<object>;
+                if (propertyCollection == null) return Array.Empty<string>();
+
+                List<string> tags = new List<string>();
+                foreach (var item in propertyCollection)
+                {
+                    tags.Add(item.ToString());
+                }
+
+                return tags.ToArray();
+            }
+            return Array.Empty<string>();
         }
 
         internal static LogLevel GetLevel(this LogEventLevel log)

--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessClientExtensions.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessClientExtensions.cs
@@ -37,22 +37,18 @@ namespace Serilog.Sinks.Exceptionless
             return null;
         }
 
-        internal static string[] GetTags(this LogEvent log)
+        internal static string[] GetTags(this LogEventPropertyValue value)
         {
-            if (log.Properties.TryGetValue("Tags", out LogEventPropertyValue value))
+            var propertyCollection = value.FlattenProperties() as List<object>;
+            if (propertyCollection == null) return Array.Empty<string>();
+
+            List<string> tags = new List<string>();
+            foreach (var item in propertyCollection)
             {
-                var propertyCollection = value.FlattenProperties() as List<object>;
-                if (propertyCollection == null) return Array.Empty<string>();
-
-                List<string> tags = new List<string>();
-                foreach (var item in propertyCollection)
-                {
-                    tags.Add(item.ToString());
-                }
-
-                return tags.ToArray();
+                tags.Add(item.ToString());
             }
-            return Array.Empty<string>();
+
+            return tags.ToArray();
         }
 
         internal static LogLevel GetLevel(this LogEventLevel log)

--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
@@ -108,7 +108,7 @@ namespace Serilog.Sinks.Exceptionless {
             if (logEvent.Level.GetLevel() < minLogLevel)
                 return;
 
-            var builder = _client.CreateFromLogEvent(logEvent).AddTags(_defaultTags);
+            var builder = _client.CreateFromLogEvent(logEvent).AddTags(_defaultTags).AddTags(logEvent.GetTags());
 
             if (_includeProperties) {
                 foreach (var prop in logEvent.Properties)

--- a/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
+++ b/src/Serilog.Sinks.Exceptionless/Sinks/Exceptionless/ExceptionlessSink.cs
@@ -108,7 +108,7 @@ namespace Serilog.Sinks.Exceptionless {
             if (logEvent.Level.GetLevel() < minLogLevel)
                 return;
 
-            var builder = _client.CreateFromLogEvent(logEvent).AddTags(_defaultTags).AddTags(logEvent.GetTags());
+            var builder = _client.CreateFromLogEvent(logEvent).AddTags(_defaultTags);
 
             if (_includeProperties) {
                 foreach (var prop in logEvent.Properties)
@@ -138,6 +138,9 @@ namespace Serilog.Sinks.Exceptionless {
                             string description = userDescription[nameof(UserDescription.Description)] as string;
                             if (!String.IsNullOrWhiteSpace(emailAddress) || !String.IsNullOrWhiteSpace(description))
                                 builder.SetUserDescription(emailAddress, description);
+                            break;
+                        case "Tags":
+                            builder.AddTags(prop.Value.GetTags());
                             break;
                         default: 
                             builder.SetProperty(prop.Key, prop.Value.FlattenProperties());


### PR DESCRIPTION
   Example usage,

Serilog: Log.ForContext("Tags", new List<string>() { "Tag1", "Tag2"}).Information("Seri info");
ILogger: 
using (var scope = _logger.BeginScope(new Dictionary<string, object> { ["Tags"] = new string[] { "Test1", "Test2" }}))
{
    _logger.Log(logLevel, eventId, state, exception, formatter);
}

![image](https://github.com/user-attachments/assets/7e120e03-e6a0-460f-ba8a-9b020cb195cc)


