### PR TITLE
use correct framework

### DIFF
--- a/sample/ConsoleDemo/ConsoleDemo.csproj
+++ b/sample/ConsoleDemo/ConsoleDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net80</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)